### PR TITLE
Add libc++ (fixes #6)

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -133,8 +133,8 @@ prepare() {
     svn export --force "${srcdir}/libcxx" projects/libcxx
     svn export --force "${srcdir}/libcxxabi" projects/libcxxabi
 
-    sed -i 's/CREDITS.TXT/CREDITS/' llvm/projects/libcxx/LICENSE.TXT
-    sed -i 's/CREDITS.TXT/CREDITS/' llvm/projects/libcxxabi/LICENSE.TXT
+    sed -i 's/CREDITS.TXT/CREDITS/' projects/libcxx/LICENSE.TXT
+    sed -i 's/CREDITS.TXT/CREDITS/' projects/libcxxabi/LICENSE.TXT
 
     mkdir -p "${srcdir}/build"
 }


### PR DESCRIPTION
Add libc++-svn to the PKGBUILD, adapting some lines from the libc++ PKGBUILD,
to be found at https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=libc%2B%2B.

I still have to test this a bit more, but it should generally work.